### PR TITLE
Fixing the DisableSaturnSkyChase option

### DIFF
--- a/SA1_Chars/SA1_Chars.cpp
+++ b/SA1_Chars/SA1_Chars.cpp
@@ -26,7 +26,7 @@
 enum MSHoverBehavior { Normal, Swap, Always };
 enum StretchyShoesBehavior { Regular, LSShoeMorphs, Disable };
 
-static bool SaturnSkyChase = true;
+static bool DisableSaturnSkyChase = false;
 static int StretchyShoes = Regular;
 static int MSHover = Normal;
 static bool EnableCDMetalSonic = true;
@@ -3292,7 +3292,7 @@ extern "C" __declspec(dllexport) void __cdecl Init(const char *path, const Helpe
 	//Ini Configuration
 	const IniFile *config = new IniFile(std::string(path) + "\\config.ini");
 	EnableCDMetalSonic = config->getBool("Characters", "EnableCDMetalSonic", true);
-	SaturnSkyChase = config->getBool("SkyChase", "DisableSaturnSkyChase", true);
+	DisableSaturnSkyChase = config->getBool("SkyChase", "DisableSaturnSkyChase", false);
 
 	std::string MSHover_String = "Normal";
 	MSHover_String = config->getString("Characters", "MetalSonicHoverBehavior", "Normal");
@@ -4321,7 +4321,7 @@ extern "C" __declspec(dllexport) void __cdecl Init(const char *path, const Helpe
 	ReplacePVM("EV_EGGMOBLE0", "EV_EGGMOBLE0_DC");
 
 	//Sky Chase
-	if (SaturnSkyChase)
+	if (DisableSaturnSkyChase)
 	{
 		WriteData((NJS_OBJECT**)0x0028B7A0C, &Tornado1_Object);
 		WriteData((NJS_OBJECT**)0x0028BA71C, &Tornado1_Object);


### PR DESCRIPTION
This fixes issue #23.

The default value for DisableSaturnSkyChase in the config schema is set to false, however in the mod it defaulted to true. When the default option is not changed in the mod's configuration, the Mod Manager doesn't write the value to the ini. Because of this, even if DisableSaturnSkyChase was turned off in the mod's config, the mod still assumed it was enabled.
I also renamed the variable to avoid potential confusion.